### PR TITLE
Use latest version of Tycho, jacoco-maven-plugin and Eclipse in Tycho example

### DIFF
--- a/projects/tycho/plugin.tests/META-INF/MANIFEST.MF
+++ b/projects/tycho/plugin.tests/META-INF/MANIFEST.MF
@@ -4,5 +4,5 @@ Bundle-Name: Example Plug-in Tests
 Bundle-SymbolicName: plugin.tests
 Bundle-Version: 1.0.0.qualifier
 Bundle-RequiredExecutionEnvironment: J2SE-1.5
-Require-Bundle: org.junit4;bundle-version="[4.0.0,5.0.0)",
+Require-Bundle: org.junit;bundle-version="[4.0.0,5.0.0)",
  plugin;bundle-version="1.0.0"

--- a/projects/tycho/pom.xml
+++ b/projects/tycho/pom.xml
@@ -60,7 +60,7 @@
     <repository>
       <id>eclipse-indigo</id>
       <layout>p2</layout>
-      <url>http://download.eclipse.org/releases/indigo</url>
+      <url>http://download.eclipse.org/releases/kepler</url>
     </repository>
   </repositories>
 

--- a/projects/tycho/pom.xml
+++ b/projects/tycho/pom.xml
@@ -32,14 +32,17 @@
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-maven-plugin</artifactId>
+        <version>0.19.0</version>
         <extensions>true</extensions>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.5.3.201107060350</version>
+        <version>0.6.4.201312101107</version>
         <configuration>
-          <includes>example.*</includes>
+          <includes>
+	       <include>example.*</include>
+          </includes>
           <destFile>${project.basedir}/../target/jacoco.exec</destFile>
         </configuration>
         <executions>

--- a/projects/tycho/pom.xml
+++ b/projects/tycho/pom.xml
@@ -58,7 +58,7 @@
 
   <repositories>
     <repository>
-      <id>eclipse-indigo</id>
+      <id>eclipse-kepler</id>
       <layout>p2</layout>
       <url>http://download.eclipse.org/releases/kepler</url>
     </repository>

--- a/projects/tycho/pom.xml
+++ b/projects/tycho/pom.xml
@@ -32,7 +32,6 @@
       <plugin>
         <groupId>org.eclipse.tycho</groupId>
         <artifactId>tycho-maven-plugin</artifactId>
-        <version>0.12.0</version>
         <extensions>true</extensions>
       </plugin>
       <plugin>


### PR DESCRIPTION
Use latest version of:
- Tycho: 0.12.0 to 0.19.0
- jacoco-maven-plugin: 0.5.3.201107060350 to 0.6.4.201312101107, need to modify 'includes' tag
- Eclipse Target Platform: indigo to Kepler, need to modify junit dependency