### PR TITLE
'symbolType' usage requires jar dependencies in scanner for unit tests

### DIFF
--- a/plugins/java-custom-rules/pom.xml
+++ b/plugins/java-custom-rules/pom.xml
@@ -23,7 +23,7 @@
 			<groupId>org.codehaus.sonar-plugins.java</groupId>
 			<artifactId>sonar-java-plugin</artifactId>
 			<type>sonar-plugin</type>
-			<version>3.1-SNAPSHOT</version>
+			<version>3.1</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/plugins/java-custom-rules/src/main/java/org/sonar/samples/java/AvoidSuperClassCheck.java
+++ b/plugins/java-custom-rules/src/main/java/org/sonar/samples/java/AvoidSuperClassCheck.java
@@ -1,0 +1,50 @@
+/*
+ * Creation : 20 avr. 2015
+ */
+package org.sonar.samples.java;
+
+import com.google.common.collect.ImmutableList;
+import org.sonar.check.Rule;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.tree.ClassTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+import java.util.List;
+
+/**
+ * Only to bring out the unit test requirement about classpath when bytecode methods used (see rule unit test class)
+ */
+@Rule(key = "avoid_super_class",
+  name = "Avoid using SuperClass",
+  description = "My stupid rule to avoid extends some SuperClass",
+  tags = {"stupid", "example"})
+public class AvoidSuperClassCheck extends IssuableSubscriptionVisitor {
+
+  public final static List<String> SUPER_CLASS_AVOID = ImmutableList.of("org.apache.log4j.Logger");
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    // Register to the kind of nodes you want to be called upon visit.
+    return ImmutableList.of(Tree.Kind.CLASS);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    // Visit CLASS node only => cast could be done
+    ClassTree treeClazz = (ClassTree) tree;
+
+    // No extends => stop to visit class
+    if (treeClazz.superClass() == null) {
+      return;
+    }
+
+    // For 'symbolType' usage, jar in dependencies must be on classpath, !unknownSymbol! result otherwise
+    String superClassName = treeClazz.superClass().symbolType().fullyQualifiedName();
+
+    // Check if superClass avoid
+    if (SUPER_CLASS_AVOID.contains(superClassName)) {
+      addIssue(tree, String.format("The usage of super class %s is forbidden", superClassName));
+    }
+  }
+
+}

--- a/plugins/java-custom-rules/src/test/files/AvoidSuperClassCheck.java
+++ b/plugins/java-custom-rules/src/test/files/AvoidSuperClassCheck.java
@@ -1,0 +1,17 @@
+/*
+ * Creation : 20 avr. 2015
+ */
+package org.sonar.samples.java;
+
+import org.apache.log4j.Logger;
+
+/**
+ * A class with extends another class outside the JVM but in classpath
+ */
+public class AvoidSuperClassCheck extends Logger {
+
+  protected AvoidSuperClassCheck(String name) {
+    super(name);
+  }
+
+}

--- a/plugins/java-custom-rules/src/test/java/org/sonar/samples/java/AvoidSuperClassCheckTest.java
+++ b/plugins/java-custom-rules/src/test/java/org/sonar/samples/java/AvoidSuperClassCheckTest.java
@@ -1,0 +1,45 @@
+/*
+ * Creation : 20 avr. 2015
+ */
+package org.sonar.samples.java;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.sonar.java.JavaAstScanner;
+import org.sonar.java.model.VisitorsBridge;
+import org.sonar.squidbridge.api.SourceFile;
+import org.sonar.squidbridge.checks.CheckMessagesVerifierRule;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class AvoidSuperClassCheckTest {
+
+  /** JAR dependencies for classpath execution */
+  private static final List<File> CLASSPATH_JAR;
+
+  static {
+    // Jar ClassPath construction. Don't use 'ClassLoader.getSystemClassLoader()', because with Maven+Surefire/Jacoco execution, only
+    // surefirebooter.jar & jacoco.agent-version-runtime.jar are on classpath => 'old schoold way'
+    CLASSPATH_JAR = new ArrayList<>();
+    for (String jar : System.getProperty("java.class.path").split(File.pathSeparator)) {
+      if (jar.endsWith(".jar")) {
+        CLASSPATH_JAR.add(new File(jar));
+      }
+    }
+  }
+
+  @Rule
+  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
+
+  @Test
+  public void checkWithJarDependenciesInClassPath() throws Exception {
+    AvoidSuperClassCheck customRule = new AvoidSuperClassCheck();
+
+    // 'symbolType' used in custom rule => unit test scanner requires project jar dependencies
+    SourceFile file = JavaAstScanner.scanSingleFile(new File("src/test/files/AvoidSuperClassCheck.java"), new VisitorsBridge(customRule, CLASSPATH_JAR));
+
+    checkMessagesVerifier.verify(file.getCheckMessages()).next().atLine(11);
+  }
+}


### PR DESCRIPTION
'symbolType' usage requires jar dependencies in scanner for unit tests.
Wihout that *superClass().symbolType()* result is *!unknownSymbol!*.
=> Tips for classpath construction and usage in scanner.

Come from this thread on dev mailing list : [Java plugin version 3.1 - Question about Symbol (superClass & method) ](http://sonarqube.15.x6.nabble.com/sonar-dev-Java-plugin-version-3-1-Question-about-Symbol-superClass-amp-method-td5033988.html)