### PR TITLE
SONARJAVA-1279 Use JavaCheckVerifier to test rules

### DIFF
--- a/plugins/java-custom-rules/pom.xml
+++ b/plugins/java-custom-rules/pom.xml
@@ -28,6 +28,13 @@
 		</dependency>
 
 		<dependency>
+            <groupId>org.sonarsource.java</groupId>
+            <artifactId>java-checks-testkit</artifactId>
+            <version>3.6-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+
+		<dependency>
 			<groupId>org.codehaus.sonar.sslr</groupId>
 			<artifactId>sslr-testing-harness</artifactId>
 			<version>1.19.2</version>

--- a/plugins/java-custom-rules/pom.xml
+++ b/plugins/java-custom-rules/pom.xml
@@ -28,11 +28,11 @@
 		</dependency>
 
 		<dependency>
-            <groupId>org.sonarsource.java</groupId>
-            <artifactId>java-checks-testkit</artifactId>
-            <version>3.6-SNAPSHOT</version>
-            <scope>test</scope>
-        </dependency>
+			<groupId>org.sonarsource.java</groupId>
+			<artifactId>java-checks-testkit</artifactId>
+			<version>3.6-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>org.codehaus.sonar.sslr</groupId>
@@ -80,6 +80,32 @@
 					<source>1.7</source>
 					<target>1.7</target>
 				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>2.10</version>
+				<executions>
+					<execution>
+						<id>copy</id>
+						<phase>test-compile</phase>
+						<goals>
+							<goal>copy</goal>
+						</goals>
+						<configuration>
+							<artifactItems>
+								<artifactItem>
+									<groupId>org.apache.commons</groupId>
+									<artifactId>commons-collections4</artifactId>
+									<version>4.0</version>
+									<type>jar</type>
+								</artifactItem>
+							</artifactItems>
+							<outputDirectory>${project.build.directory}/test-jars</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/plugins/java-custom-rules/src/main/java/org/sonar/samples/java/MyJavaFileCheckRegistrar.java
+++ b/plugins/java-custom-rules/src/main/java/org/sonar/samples/java/MyJavaFileCheckRegistrar.java
@@ -30,8 +30,13 @@ public class MyJavaFileCheckRegistrar implements CheckRegistrar {
    * Lists all the checks provided by the plugin
    */
   public static Class<? extends JavaCheck>[] checkClasses() {
-    return new Class[] {SecurityAnnotationMandatoryCheck.class, MyCustomSubscriptionRule.class, AvoidAnnotationCheck.class, AvoidMethodDeclarationCheck.class,
-      AvoidBrandInMethodNamesCheck.class};
+    return new Class[] {
+      SecurityAnnotationMandatoryCheck.class, 
+      MyCustomSubscriptionRule.class, 
+      AvoidAnnotationCheck.class, 
+      AvoidMethodDeclarationCheck.class,
+      AvoidBrandInMethodNamesCheck.class
+      };
   }
 
   /**

--- a/plugins/java-custom-rules/src/main/java/org/sonar/samples/java/MyJavaFileCheckRegistrar.java
+++ b/plugins/java-custom-rules/src/main/java/org/sonar/samples/java/MyJavaFileCheckRegistrar.java
@@ -7,6 +7,7 @@ import org.sonar.plugins.java.api.JavaCheck;
 import org.sonar.samples.java.checks.AvoidAnnotationCheck;
 import org.sonar.samples.java.checks.AvoidBrandInMethodNamesCheck;
 import org.sonar.samples.java.checks.AvoidMethodDeclarationCheck;
+import org.sonar.samples.java.checks.MyCustomSubscriptionRule;
 import org.sonar.samples.java.checks.SecurityAnnotationMandatoryCheck;
 
 /**

--- a/plugins/java-custom-rules/src/main/java/org/sonar/samples/java/checks/AvoidUnmodifiableList.java
+++ b/plugins/java-custom-rules/src/main/java/org/sonar/samples/java/checks/AvoidUnmodifiableList.java
@@ -1,0 +1,30 @@
+package org.sonar.samples.java.checks;
+
+import com.google.common.collect.ImmutableList;
+import org.sonar.check.Rule;
+import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
+import org.sonar.plugins.java.api.tree.NewClassTree;
+import org.sonar.plugins.java.api.tree.Tree;
+
+import java.util.List;
+
+@Rule(
+  key = "AvoidUnmodifiableList",
+  name = "Avoid usage of UnmodifiableList",
+  description = "This rule detects instanciation of apache commons collections UnmodifableList",
+  tags = {"example"})
+public class AvoidUnmodifiableList extends IssuableSubscriptionVisitor {
+
+  @Override
+  public List<Tree.Kind> nodesToVisit() {
+    return ImmutableList.of(Tree.Kind.NEW_CLASS);
+  }
+
+  @Override
+  public void visitNode(Tree tree) {
+    if (((NewClassTree) tree).symbolType().isSubtypeOf("org.apache.commons.collections4.list.UnmodifiableList")) {
+      addIssue(tree, "Avoid using UnmodifiableList");
+    }
+  }
+
+}

--- a/plugins/java-custom-rules/src/main/java/org/sonar/samples/java/checks/MyCustomSubscriptionRule.java
+++ b/plugins/java-custom-rules/src/main/java/org/sonar/samples/java/checks/MyCustomSubscriptionRule.java
@@ -1,4 +1,4 @@
-package org.sonar.samples.java;
+package org.sonar.samples.java.checks;
 
 import java.util.List;
 

--- a/plugins/java-custom-rules/src/test/files/AvoidAnnotationCheck.java
+++ b/plugins/java-custom-rules/src/test/files/AvoidAnnotationCheck.java
@@ -11,7 +11,7 @@ class AvoidAnnotationCheck {
 
   }
 
-  @Zuper // We expect an issue at this line.
+  @Zuper // Noncompliant {{Avoid using annotation @Zuper}}
   public void aMethod() {
 
   }

--- a/plugins/java-custom-rules/src/test/files/AvoidUnmodifiableList.java
+++ b/plugins/java-custom-rules/src/test/files/AvoidUnmodifiableList.java
@@ -1,0 +1,17 @@
+import org.apache.commons.collections4.list.UnmodifiableList;
+import java.util.ArrayList;
+
+import java.util.ArrayList;
+
+class A {
+  void foo() {
+    UnmodifiableList myList = new UnmodifiableList(new ArrayList<>()); // Noncompliant {{Avoid using UnmodifiableList}}
+    // Noncompliant@+1
+    MyList myOtherList = new MyList(); // as MyList extends the UnmodifiableList, we expect an issue here
+  }
+}
+
+class MyList extends UnmodifiableList {
+  public MyList() {
+  }
+}

--- a/plugins/java-custom-rules/src/test/java/org/sonar/samples/java/checks/AvoidAnnotationCheckTest.java
+++ b/plugins/java-custom-rules/src/test/java/org/sonar/samples/java/checks/AvoidAnnotationCheckTest.java
@@ -1,18 +1,9 @@
 package org.sonar.samples.java.checks;
 
-import java.io.File;
-
-import org.junit.Rule;
 import org.junit.Test;
-import org.sonar.java.ast.JavaAstScanner;
-import org.sonar.java.model.VisitorsBridge;
-import org.sonar.squidbridge.api.SourceFile;
-import org.sonar.squidbridge.checks.CheckMessagesVerifierRule;
+import org.sonar.java.checks.verifier.JavaCheckVerifier;
 
 public class AvoidAnnotationCheckTest {
-
-  @Rule
-  public CheckMessagesVerifierRule checkMessagesVerifier = new CheckMessagesVerifierRule();
 
   @Test
   public void detected() {
@@ -21,11 +12,7 @@ public class AvoidAnnotationCheckTest {
     AvoidAnnotationCheck check = new AvoidAnnotationCheck();
     check.name = "Zuper";
 
-    SourceFile file = JavaAstScanner
-      .scanSingleFile(new File("src/test/files/AvoidAnnotationCheck.java"), new VisitorsBridge(check));
-
-    // Check the message raised by the check
-    checkMessagesVerifier.verify(file.getCheckMessages())
-      .next().atLine(14).withMessage("Avoid using annotation @Zuper");
+    // Verifies that the check will raise the adequate issues with the expected message
+    JavaCheckVerifier.verify("src/test/files/AvoidAnnotationCheck.java", check);
   }
 }

--- a/plugins/java-custom-rules/src/test/java/org/sonar/samples/java/checks/AvoidUnmodifiableListTest.java
+++ b/plugins/java-custom-rules/src/test/java/org/sonar/samples/java/checks/AvoidUnmodifiableListTest.java
@@ -1,0 +1,18 @@
+package org.sonar.samples.java.checks;
+
+import org.junit.Test;
+import org.sonar.java.checks.verifier.JavaCheckVerifier;
+
+public class AvoidUnmodifiableListTest {
+
+  @Test
+  public void verify() {
+    // In order to test this check efficiently, we added the test-jar "org.apache.commons.commons-collections4" to the pom,
+    // which is normally not used by the code of our custom plugin.
+    // All the classes from this jar will then be read when verifying the ticket, allowing correct type resolution.
+
+    // Verifies automatically that the check will raise the adequate issues with the expected message
+    JavaCheckVerifier.verify("src/test/files/AvoidUnmodifiableList.java", new AvoidUnmodifiableList());
+  }
+
+}

--- a/plugins/java-custom-rules/src/test/java/org/sonar/samples/java/checks/MyCustomSubscriptionRuleTest.java
+++ b/plugins/java-custom-rules/src/test/java/org/sonar/samples/java/checks/MyCustomSubscriptionRuleTest.java
@@ -6,7 +6,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.sonar.java.ast.JavaAstScanner;
 import org.sonar.java.model.VisitorsBridge;
-import org.sonar.samples.java.MyCustomSubscriptionRule;
 import org.sonar.squidbridge.api.SourceFile;
 import org.sonar.squidbridge.checks.CheckMessagesVerifierRule;
 


### PR DESCRIPTION
- Update AvoidAnnotationCheck Unit Test in order to use the newly exposed JavaCheckVerifier
- Added new rule example requiring external jar to be tested correctly, using a test-jar

**Note:** This PR should be merged only after the release of version 3.6 of the JAVA plugin, in order to avoid dependency of SNAPSHOT in the pom.